### PR TITLE
Fix currentUserId usage in document manager

### DIFF
--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -2,6 +2,7 @@
 
 import { canvas } from './canvas-core.js'; // Importa el canvas
 import { saveCanvasToHistory } from './canvas-history.js'; // Importa la función de historial
+import { currentUserId } from './canvas-persistence.js'; // Importar ID de usuario persistente
 
 // Asumimos que firebase.firestore() y firebase.storage() son globales o se pasan desde main-app.js
 const db = firebase.firestore();
@@ -13,7 +14,7 @@ export const USER_STORAGE_LIMIT_BYTES = 50 * 1024 * 1024; // Límite de 50 MB
 // --- Funciones de Gestión de Documentos (Firebase Storage y Firestore) ---
 
 // Función para actualizar el uso de almacenamiento del usuario
-export async function updateUserStorageUsage(currentUserId) {
+export async function updateUserStorageUsage() {
     if (!currentUserId) return;
     try {
         const userDocRef = db.collection('users').doc(currentUserId);
@@ -80,7 +81,7 @@ export async function uploadImageAndAddToCanvas(file, clientX, clientY) {
 }
 
 // Cargar documentos para la materia actual (ahora solo PDFs/TXT locales)
-export async function loadDocumentsForCurrentSubject(currentUserId, currentSubjectId, localFilesSection) {
+export async function loadDocumentsForCurrentSubject(currentSubjectId, localFilesSection) {
     if (!currentUserId) {
         console.warn('DocumentManager: loadDocumentsForCurrentSubject: No se pueden cargar documentos: usuario no autenticado.');
         return;

--- a/ShareboardApp/js/main-app.js
+++ b/ShareboardApp/js/main-app.js
@@ -54,8 +54,8 @@ document.addEventListener('DOMContentLoaded', () => {
             initializeTools(toolBtns, isTextEditingFlagCallback); 
 
             // Cargar documentos del panel lateral (solo los locales en esta versión)
-            loadDocumentsForCurrentSubject(firebase.auth().currentUser.uid, currentSubjectId, localFilesSection);
-            updateUserStorageUsage(firebase.auth().currentUser.uid); 
+            loadDocumentsForCurrentSubject(currentSubjectId, localFilesSection);
+            updateUserStorageUsage();
 
             // Manejar la imagen capturada del visor de PDF si existe en sessionStorage
             const capturedImage = sessionStorage.getItem('capturedImage');
@@ -97,8 +97,8 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('Main-App: Materia cambiada a:', newSubjectName, 'ID:', newSubjectId);
         alert(`Cambiando a la materia: ${newSubjectName}`);
         
-        loadCanvasState(newSubjectId); 
-        loadDocumentsForCurrentSubject(firebase.auth().currentUser.uid, newSubjectId, localFilesSection);
+        loadCanvasState(newSubjectId);
+        loadDocumentsForCurrentSubject(newSubjectId, localFilesSection);
     });
 
     newSubjectBtn.addEventListener('click', async () => {
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
             canvas.renderAll();
             saveCanvasToHistory();
             saveCanvasState();
-            loadDocumentsForCurrentSubject(firebase.auth().currentUser.uid, newSubjectId, localFilesSection);
+            loadDocumentsForCurrentSubject(newSubjectId, localFilesSection);
         }
     });
 


### PR DESCRIPTION
## Summary
- import `currentUserId` in `document-manager`
- use imported `currentUserId` for storage updates and document loading
- update `main-app` calls to new signatures

## Testing
- `grep -n "loadDocumentsForCurrentSubject" -n js/main-app.js`


------
https://chatgpt.com/codex/tasks/task_e_68411113ab0083278a7fc9af9aa93046