### PR TITLE
Improve canvas error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ Uploads are restricted to keep storage usage reasonable:
 - Local documents loaded in the sidebar must be **10 MB or smaller**.
 
 Refer to `js/document-manager.js` for the exact checks.
+
+## Troubleshooting
+
+If loading a canvas fails you may see an alert containing a Firebase error code
+such as `permission-denied` or `unavailable`. This message now includes the
+specific code or network error from Firestore. Verify your internet connection
+and check Firestore permissions if the problem persists.

--- a/ShareboardApp/js/canvas-persistence.js
+++ b/ShareboardApp/js/canvas-persistence.js
@@ -77,8 +77,24 @@ export async function loadCanvasState(subjectId) {
         }
     } catch (error) {
         console.error('Persistence: Error al cargar el lienzo desde Firestore:', error);
-        if (error.code !== 'not-found' && !String(error).includes('fabric')) { 
-            alert('Error al cargar el lienzo. Reiniciando...');
+        if (error.code !== 'not-found' && !String(error).includes('fabric')) {
+            let message = '';
+            switch (error.code) {
+                case 'permission-denied':
+                    message = 'No tienes permiso para acceder a esta materia.';
+                    break;
+                case 'unavailable':
+                    message = 'Servicio no disponible. Verifica tu conexión.';
+                    break;
+                default:
+                    if (error.message && /network/i.test(error.message)) {
+                        message = `Problema de red: ${error.message}`;
+                    } else {
+                        message = `Error al cargar el lienzo (${error.code || error.message}). Reiniciando...`;
+                    }
+                    break;
+            }
+            alert(message);
         }
         canvas.clear();
         canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);


### PR DESCRIPTION
## Summary
- clarify Firestore error alerts in `loadCanvasState`
- document new troubleshooting guidance

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841111469588327936a32aa9e1ff4dc