### PR TITLE
Fix canvas loading and const conflicts

### DIFF
--- a/ShareboardApp/js/canvas-history.js
+++ b/ShareboardApp/js/canvas-history.js
@@ -5,7 +5,13 @@ import { saveCanvasState } from './canvas-persistence.js';
 
 export let canvasHistory = [];
 export let historyPointer = -1;
-export let isRedoing = false; 
+export let isRedoing = false;
+
+export function resetHistory() {
+    canvasHistory.length = 0;
+    historyPointer = -1;
+    isRedoing = false;
+}
 
 export function saveCanvasToHistory() {
     if (!canvas) {

--- a/ShareboardApp/js/canvas-persistence.js
+++ b/ShareboardApp/js/canvas-persistence.js
@@ -1,7 +1,7 @@
 // js/canvas-persistence.js
 
-import { canvas, viewport } from './canvas-core.js'; 
-import { canvasHistory, historyPointer, isRedoing, saveCanvasToHistory } from './canvas-history.js'; // Importar variables y función de historial
+import { canvas, viewport } from './canvas-core.js';
+import { saveCanvasToHistory, resetHistory } from './canvas-history.js';
 
 const db = firebase.firestore();
 
@@ -49,9 +49,7 @@ export async function loadCanvasState(subjectId) {
             
             // Reiniciar historial aquí para evitar conflictos con el historial del lienzo anterior
             // No re-declarar, solo re-inicializar los arrays/punteros
-            canvasHistory.length = 0; // Vaciar el array
-            historyPointer = -1;
-            isRedoing = false;
+            resetHistory();
 
             canvas.loadFromJSON(loadedCanvasData, () => {
                 canvas.setViewportTransform([loadedViewport.zoom, 0, 0, loadedViewport.zoom, loadedViewport.x, loadedViewport.y]);
@@ -70,9 +68,7 @@ export async function loadCanvasState(subjectId) {
             canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);
             viewport.x = 0; viewport.y = 0; viewport.zoom = 1; // Resetear viewport global
             canvas.renderAll();
-            canvasHistory.length = 0; // Vaciar el array
-            historyPointer = -1;
-            isRedoing = false;
+            resetHistory();
             saveCanvasToHistory();
         }
     } catch (error) {
@@ -100,9 +96,7 @@ export async function loadCanvasState(subjectId) {
         canvas.setViewportTransform([1, 0, 0, 1, 0, 0]);
         viewport.x = 0; viewport.y = 0; viewport.zoom = 1;
         canvas.renderAll();
-        canvasHistory.length = 0;
-        historyPointer = -1;
-        isRedoing = false;
+        resetHistory();
         saveCanvasToHistory();
     }
 }


### PR DESCRIPTION
## Summary
- add `resetHistory` helper to update history state
- use `resetHistory` in `canvas-persistence`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841161edbb88327903bd76254c26bf9