### PR TITLE
Fix tool initialization with canvas

### DIFF
--- a/ShareboardApp/js/canvas-tools.js
+++ b/ShareboardApp/js/canvas-tools.js
@@ -1,8 +1,15 @@
 // js/canvas-tools.js
 
-import { canvas } from './canvas-core.js'; 
-import { saveCanvasToHistory, undo, redo } from './canvas-history.js'; 
-import { uploadImageAndAddToCanvas } from './document-manager.js'; 
+import { saveCanvasToHistory, undo, redo } from './canvas-history.js';
+import { uploadImageAndAddToCanvas } from './document-manager.js';
+
+// Referencia al canvas de Fabric.js proporcionada externamente
+let canvas = null;
+
+// Inicializa la referencia al canvas. Debe llamarse una vez que el lienzo esté creado.
+export function initTools(canvasInstance) {
+    canvas = canvasInstance;
+}
 
 // Bandera para controlar el modo de edición de texto (interna al módulo)
 let isTextEditingInternal = false;

--- a/ShareboardApp/js/main-app.js
+++ b/ShareboardApp/js/main-app.js
@@ -4,7 +4,7 @@
 import { initializeCanvas, canvas, viewport } from './canvas-core.js'; 
 import { saveCanvasState, loadCanvasState, setPersistenceUserId, currentSubjectId } from './canvas-persistence.js'; 
 import { saveCanvasToHistory, undo, redo } from './canvas-history.js'; 
-import { initializeTools } from './canvas-tools.js'; // isTextEditingGlobal ya no se importa aquí
+import { initializeTools, initTools } from './canvas-tools.js'; // isTextEditingGlobal ya no se importa aquí
 import { updateUserStorageUsage, uploadImageAndAddToCanvas, loadDocumentsForCurrentSubject, handleLocalDocument, addDocumentToCanvas } from './document-manager.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -42,7 +42,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             // Inicializar el canvas de Fabric.js
-            initializeCanvas(mainCanvasContainer); 
+            initializeCanvas(mainCanvasContainer);
+            // Proporcionar el canvas a las herramientas una vez creado
+            initTools(canvas);
             
             // Cargar el lienzo inicial y su historial
             loadCanvasState(currentSubjectId); 
@@ -199,10 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // 4. Funcionalidad de la barra de herramientas (delegada a canvas-tools.js)
-    initializeTools(toolBtns, (isEditing) => {
-        isTextEditingFromTools = isEditing; 
-    }); 
+
 
     // 6. Funcionalidad de Cerrar Sesión
     logoutBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- refactor canvas-tools to delay canvas access until initialized
- setup tools with new `initTools` function in main-app
- remove duplicate tool initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841175e2e048327a2c50339fdc8ce28