### PR TITLE
Handle PDF blobs by URL

### DIFF
--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -217,16 +217,13 @@ export function handleLocalDocument(file, localFilesSection) {
         `;
         docElement.addEventListener('click', () => {
             if (file.type === 'application/pdf') {
-                // Almacenar el archivo PDF en sessionStorage antes de redirigir
-                const readerForSession = new FileReader();
-                readerForSession.onload = (eventSession) => {
-                    sessionStorage.setItem('currentPdfData', JSON.stringify({
-                        type: 'ArrayBuffer',
-                        data: Array.from(new Uint8Array(eventSession.target.result))
-                    }));
-                    window.location.href = 'pdf-viewer-page.html'; // Redirigir a la nueva página del visor
-                };
-                readerForSession.readAsArrayBuffer(file);
+                // Crear una URL de objeto para el PDF y almacenarla en sessionStorage
+                const blobUrl = URL.createObjectURL(file);
+                sessionStorage.setItem('currentPdfData', JSON.stringify({
+                    type: 'url',
+                    url: blobUrl
+                }));
+                window.location.href = 'pdf-viewer-page.html'; // Redirigir a la nueva página del visor
             } else if (file.type === 'text/plain') {
                 alert(`Contenido de ${file.name}:\n\n${fileUrl}`);
             } else {

--- a/ShareboardApp/js/pdf-viewer-page.js
+++ b/ShareboardApp/js/pdf-viewer-page.js
@@ -131,7 +131,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 const arrayBuffer = new Uint8Array(pdfData.data).buffer;
                 loadAndRenderPdf({data: arrayBuffer});
             } else if (pdfData.type === 'url') {
-                loadAndRenderPdf({url: pdfData.url});
+                const objectUrl = pdfData.url;
+                loadAndRenderPdf({url: objectUrl}).then(() => {
+                    URL.revokeObjectURL(objectUrl);
+                });
             } else {
                 console.error('PDF Viewer: Tipo de datos de PDF no reconocido en sessionStorage.');
                 alert('Error al cargar el PDF desde la sesión. Formato no reconocido.');


### PR DESCRIPTION
## Summary
- load PDF files using `URL.createObjectURL` instead of storing ArrayBuffers
- revoke object URLs after rendering PDFs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841196a6f108327ac0fde600a62213c