### PR TITLE
Fix: carga local de PDF con validación y error handling

### DIFF
--- a/ShareboardApp/pdf-viewer-page.html
+++ b/ShareboardApp/pdf-viewer-page.html
@@ -27,6 +27,10 @@
             <canvas id="pdfViewerCanvas"></canvas>
         </div>
 
+        <div class="local-pdf-selector">
+            <input type="file" id="localPdfInput" accept="application/pdf">
+        </div>
+
         <div class="viewer-controls-bottom">
             <button id="prevPageBtn" class="viewer-btn material-symbols-outlined">arrow_back</button>
             <span id="pageInfoBottom">Página: 1 / ?</span>


### PR DESCRIPTION
## Summary
- add input for local PDF file selection
- verify remote PDF exists before loading with PDF.js
- load selected PDF via FileReader and Uint8Array
- handle errors when the PDF is invalid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411b2551888327a0bc90584c3aa689