### PR TITLE
Fix: carga de PDF sin errores de blob usando FileReader y render con PDF.js

### DIFF
--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -200,13 +200,13 @@ export function handleLocalDocument(file, localFilesSection) {
 
     const reader = new FileReader();
     reader.onload = (e) => {
-        const fileUrl = e.target.result;
+        const fileData = e.target.result;
 
         const docElement = document.createElement('div');
         docElement.classList.add('document-item', 'local-doc');
-        docElement.dataset.fileObject = file.type === 'application/pdf' ? 'true' : 'false'; 
-        if (file.type !== 'application/pdf') { 
-            docElement.dataset.url = fileUrl;
+        docElement.dataset.fileObject = file.type === 'application/pdf' ? 'true' : 'false';
+        if (file.type !== 'application/pdf') {
+            docElement.dataset.url = fileData;
         }
         docElement.dataset.type = file.type;
         docElement.dataset.name = file.name;
@@ -217,15 +217,15 @@ export function handleLocalDocument(file, localFilesSection) {
         `;
         docElement.addEventListener('click', () => {
             if (file.type === 'application/pdf') {
-                // Crear una URL de objeto para el PDF y almacenarla en sessionStorage
-                const blobUrl = URL.createObjectURL(file);
+                // Guardar el ArrayBuffer del PDF en sessionStorage para evitar errores con blobs
+                const byteArray = Array.from(new Uint8Array(fileData));
                 sessionStorage.setItem('currentPdfData', JSON.stringify({
-                    type: 'url',
-                    url: blobUrl
+                    type: 'ArrayBuffer',
+                    data: byteArray
                 }));
                 window.location.href = 'pdf-viewer-page.html'; // Redirigir a la nueva página del visor
             } else if (file.type === 'text/plain') {
-                alert(`Contenido de ${file.name}:\n\n${fileUrl}`);
+                alert(`Contenido de ${file.name}:\n\n${fileData}`);
             } else {
                 alert(`No hay visor integrado para este tipo de documento local: ${file.type}.`);
             }
@@ -234,6 +234,10 @@ export function handleLocalDocument(file, localFilesSection) {
         localFilesSection.querySelector('.empty-list-message')?.remove();
         localFilesSection.appendChild(docElement);
         console.log(`DocumentManager: Documento local '${file.name}' cargado para la sesión.`);
+    };
+
+    reader.onerror = () => {
+        alert('Error al leer el archivo seleccionado.');
     };
 
     if (file.type.startsWith('image/') || file.type === 'text/plain') {

--- a/ShareboardApp/js/pdf-viewer-page.js
+++ b/ShareboardApp/js/pdf-viewer-page.js
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- Cargar el PDF al iniciar la página ---
-    // Recuperar la URL del PDF o el ArrayBuffer de sessionStorage
+    // Recuperar el ArrayBuffer de sessionStorage
     const pdfDataString = sessionStorage.getItem('currentPdfData');
     if (pdfDataString) {
         try {
@@ -168,11 +168,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Convertir el array de vuelta a ArrayBuffer
                 const arrayBuffer = new Uint8Array(pdfData.data).buffer;
                 loadAndRenderPdf({data: arrayBuffer});
-            } else if (pdfData.type === 'url') {
-                const objectUrl = pdfData.url;
-                loadAndRenderPdf({url: objectUrl}).then(() => {
-                    URL.revokeObjectURL(objectUrl);
-                });
             } else {
                 console.error('PDF Viewer: Tipo de datos de PDF no reconocido en sessionStorage.');
                 alert('Error al cargar el PDF desde la sesión. Formato no reconocido.');


### PR DESCRIPTION
## Summary
- avoid object URLs when opening PDFs locally
- store PDF ArrayBuffer in sessionStorage
- load and render PDF from ArrayBuffer in viewer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411c34439c8327afeffbfd01ae5cc7