### PR TITLE
Handle quota errors for local PDFs

### DIFF
--- a/ShareboardApp/js/pdf-viewer-page.js
+++ b/ShareboardApp/js/pdf-viewer-page.js
@@ -159,15 +159,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // --- Cargar el PDF al iniciar la página ---
-    // Recuperar el ArrayBuffer de sessionStorage
     const pdfDataString = sessionStorage.getItem('currentPdfData');
     if (pdfDataString) {
+        let objectUrlToRevoke = null;
         try {
             const pdfData = JSON.parse(pdfDataString);
             if (pdfData.type === 'ArrayBuffer') {
-                // Convertir el array de vuelta a ArrayBuffer
                 const arrayBuffer = new Uint8Array(pdfData.data).buffer;
-                loadAndRenderPdf({data: arrayBuffer});
+                loadAndRenderPdf({ data: arrayBuffer });
+            } else if (pdfData.type === 'ObjectURL') {
+                objectUrlToRevoke = pdfData.url;
+                loadAndRenderPdf({ url: pdfData.url });
             } else {
                 console.error('PDF Viewer: Tipo de datos de PDF no reconocido en sessionStorage.');
                 alert('Error al cargar el PDF desde la sesión. Formato no reconocido.');
@@ -178,7 +180,10 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('Error al cargar el PDF desde la sesión. Datos corruptos.');
             window.location.href = 'canvas.html';
         } finally {
-            sessionStorage.removeItem('currentPdfData'); // Limpiar después de usar
+            sessionStorage.removeItem('currentPdfData');
+            if (objectUrlToRevoke) {
+                URL.revokeObjectURL(objectUrlToRevoke);
+            }
         }
     } else {
         alert('No se encontró ningún PDF para mostrar. Volviendo al lienzo.');


### PR DESCRIPTION
## Summary
- use `URL.createObjectURL` for local PDF preview
- catch QuotaExceededError when storing PDF references
- revoke object URLs after loading in viewer

## Testing
- `node -c ShareboardApp/js/document-manager.js`
- `node -c ShareboardApp/js/pdf-viewer-page.js`


------
https://chatgpt.com/codex/tasks/task_e_6842251c652c8327bd883ead08217469