### PR TITLE
Update local file size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ PDFs or capture PDF pages onto the board.
 Uploads are restricted to keep storage usage reasonable:
 
 - Images added to the canvas must be **5 MB or smaller**.
-- Local documents loaded in the sidebar must be **10 MB or smaller**.
+ - Local documents loaded in the sidebar must be **20 MB or smaller**.
 
 Refer to `js/document-manager.js` for the exact checks.
 

--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -192,7 +192,7 @@ export function addDocumentToCanvas(fileData, clientX, clientY) {
 export function handleLocalDocument(file, localFilesSection) {
     if (!file) return;
 
-    const MAX_LOCAL_FILE_SIZE_MB = 10;
+    const MAX_LOCAL_FILE_SIZE_MB = 20;
     if (file.size > MAX_LOCAL_FILE_SIZE_MB * 1024 * 1024) {
         alert(`El documento '${file.name}' excede el tamaño máximo permitido de ${MAX_LOCAL_FILE_SIZE_MB} MB para carga local.`);
         return;


### PR DESCRIPTION
## Summary
- bump local PDF/TXT limit from 10MB to 20MB
- update README to reflect new limit

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6842308cb248832784b057aa45621282