### PR TITLE
Remove local document size cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ PDFs or capture PDF pages onto the board.
 Uploads are restricted to keep storage usage reasonable:
 
 - Images added to the canvas must be **5 MB or smaller**.
- - Local documents loaded in the sidebar must be **20 MB or smaller**.
 
 Refer to `js/document-manager.js` for the exact checks.
 

--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -201,12 +201,6 @@ export function addDocumentToCanvas(fileData, clientX, clientY) {
 export function handleLocalDocument(file, localFilesSection) {
     if (!file) return;
 
-    const MAX_LOCAL_FILE_SIZE_MB = 20;
-    if (file.size > MAX_LOCAL_FILE_SIZE_MB * 1024 * 1024) {
-        alert(`El documento '${file.name}' excede el tamaño máximo permitido de ${MAX_LOCAL_FILE_SIZE_MB} MB para carga local.`);
-        return;
-    }
-
     if (file.type === 'application/pdf') {
         const reader = new FileReader();
         reader.onload = () => {


### PR DESCRIPTION
## Summary
- drop 20MB limit when loading local documents
- mention only image limit in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68423292e1c48327b454972f5edec512