### PR TITLE
fix: manejo de nombres de archivos PDF para visualización correcta

### DIFF
--- a/ShareboardApp/js/document-manager.js
+++ b/ShareboardApp/js/document-manager.js
@@ -54,7 +54,7 @@ export async function loadDocumentsForCurrentSubject(_, localFilesSection) {
         const element = document.createElement('div');
         element.classList.add('document-item');
         element.dataset.fileObject = 'true';
-        element.dataset.url = `${BASE_URL}/uploads/${note.pdf}`;
+        element.dataset.url = `${BASE_URL}/${note.pdf}`;
         element.dataset.type = 'application/pdf';
         element.dataset.name = note.texto;
         element.draggable = true;

--- a/ShareboardApp/js/notes.js
+++ b/ShareboardApp/js/notes.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 if (nota.pdf) {
                     const enlace = document.createElement('a');
-                    enlace.href = `${BASE_URL}/uploads/${nota.pdf}`;
+                    enlace.href = `${BASE_URL}/${nota.pdf}`;
                     enlace.textContent = 'Ver PDF';
                     enlace.target = '_blank';
                     item.appendChild(enlace);


### PR DESCRIPTION
## Summary
- serve uploads folder through express.static
- sanitize uploaded file names to avoid spaces
- save cleaned names with uploads path in database
- update PDF links in notes and document manager

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684261bbdcb08327a2a9cbe558605fdc