### PR TITLE
Fix horizontal PDF captures

### DIFF
--- a/ShareboardApp/js/main-app.js
+++ b/ShareboardApp/js/main-app.js
@@ -42,8 +42,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const capturedImage = sessionStorage.getItem('capturedImage');
     if (capturedImage && canvas) {
         fabric.Image.fromURL(capturedImage, (img) => {
+            if (!img.width || !img.height) {
+                console.error('Imagen capturada inválida');
+                sessionStorage.removeItem('capturedImage');
+                return;
+            }
+
+            const maxW = canvas.width * 0.8;
+            const maxH = canvas.height * 0.8;
+            let scale = 1;
+            if (img.width > maxW || img.height > maxH) {
+                scale = Math.min(maxW / img.width, maxH / img.height);
+            }
+
             const center = canvas.getCenter();
-            img.set({ left: center.left, top: center.top, originX: 'center', originY: 'center', scaleX: 0.5, scaleY: 0.5, selectable: true, evented: true });
+            img.set({ left: center.left, top: center.top, originX: 'center', originY: 'center', scaleX: scale, scaleY: scale, selectable: true, evented: true });
             canvas.add(img);
             canvas.setActiveObject(img);
             canvas.renderAll();

--- a/ShareboardApp/js/pdf-viewer-page.js
+++ b/ShareboardApp/js/pdf-viewer-page.js
@@ -31,6 +31,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Valores mayores implican más píxeles por punto de la pantalla
     let pdfCanvasResolutionScale = 2;
 
+    // Dimensiones reales del canvas PDF para la captura
+    let currentCanvasWidth = 0;
+    let currentCanvasHeight = 0;
+
     // Tarea de renderizado actual para evitar superposiciones
     let renderTask = null;
 
@@ -120,6 +124,8 @@ document.addEventListener('DOMContentLoaded', () => {
         // Ajustar tamaño interno para alta resolución y tamaño visual sin escalado
         pdfViewerCanvas.width = renderViewport.width;
         pdfViewerCanvas.height = renderViewport.height;
+        currentCanvasWidth = renderViewport.width;
+        currentCanvasHeight = renderViewport.height;
         pdfViewerCanvas.style.width = `${displayViewport.width}px`;
         pdfViewerCanvas.style.height = `${displayViewport.height}px`;
 
@@ -161,7 +167,16 @@ document.addEventListener('DOMContentLoaded', () => {
             alert('No hay un PDF cargado en el visor para capturar.');
             return;
         }
-        const dataURL = pdfViewerCanvas.toDataURL('image/png');
+
+        // Usar las dimensiones reales del canvas PDF para asegurar una captura correcta
+        const w = currentCanvasWidth || pdfViewerCanvas.width;
+        const h = currentCanvasHeight || pdfViewerCanvas.height;
+        const captureCanvas = document.createElement('canvas');
+        captureCanvas.width = w;
+        captureCanvas.height = h;
+        const ctx = captureCanvas.getContext('2d');
+        ctx.drawImage(pdfViewerCanvas, 0, 0, w, h);
+        const dataURL = captureCanvas.toDataURL('image/png');
 
         // Almacenar la Data URL en sessionStorage y redirigir al lienzo
         sessionStorage.setItem('capturedImage', dataURL);


### PR DESCRIPTION
## Summary
- handle real canvas size when capturing PDF pages
- validate captured image before adding to canvas and scale appropriately

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68426eb27874832797197dc513d94341