### PR TITLE
fix: servidor Express configurado para servir correctamente archivos desde /uploads

### DIFF
--- a/ShareboardApp/backend/server.js
+++ b/ShareboardApp/backend/server.js
@@ -9,10 +9,10 @@ const PORT = 3000;
 
 app.use(cors());
 app.use(express.json());
-// Servir la aplicación web y los archivos subidos desde el mismo servidor
-app.use(express.static(path.join(__dirname, '..')));
 // Servir la carpeta de uploads directamente para acceder a los PDFs por URL
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+// Servir la aplicación web y los archivos subidos desde el mismo servidor
+app.use(express.static(path.join(__dirname, '..')));
 
 // Configuración de subida de archivos
 const storage = multer.diskStorage({


### PR DESCRIPTION
## Summary
- ensure Express serves `/uploads` before other static files

## Testing
- `node ShareboardApp/backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68445dfee82883279a9a92249cc51499