### PR TITLE
Add delete option for PDFs

### DIFF
--- a/ShareboardApp/js/notes.js
+++ b/ShareboardApp/js/notes.js
@@ -25,10 +25,26 @@ document.addEventListener('DOMContentLoaded', () => {
                     enlace.target = '_blank';
                     item.appendChild(enlace);
                 }
+
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Eliminar';
+                delBtn.addEventListener('click', () => eliminarNota(nota.id));
+                item.appendChild(delBtn);
+
                 lista.appendChild(item);
             });
         } catch (err) {
             console.error('Error al obtener notas:', err);
+        }
+    };
+
+    const eliminarNota = async (id) => {
+        if (!confirm('¿Eliminar este PDF?')) return;
+        try {
+            await fetch(`${API_URL}/${id}`, { method: 'DELETE' });
+            cargarNotas();
+        } catch (err) {
+            console.error('Error al eliminar nota:', err);
         }
     };
 


### PR DESCRIPTION
## Summary
- enable backend to delete notes and PDFs
- allow removing PDFs from list of notes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684461ba9744832785181456c9f5f6f9