### PR TITLE
Add brush size/color and text formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ upload PDFs or capture PDF pages onto the board.
   localmente sin servicios externos.
 - **Whiteboard** – A Fabric.js canvas provides drawing tools, image support and
   undo/redo functionality.
+- **Formatting** – Choose brush color and size and format text with bold,
+  italics, underline and different font sizes.
 - **Documents** – Upload PDFs or text files, view them in a dedicated page and
   capture pages onto the canvas for annotation.
 

--- a/ShareboardApp/canvas.html
+++ b/ShareboardApp/canvas.html
@@ -62,7 +62,30 @@
                 </div>
                 
                 <div class="toolbar-right">
-                    <button class="tool-btn active" data-tool="select"><span class="material-symbols-outlined">select_all</span></button> <button class="tool-btn" data-tool="edit"><span class="material-symbols-outlined">edit</span></button> <button class="tool-btn" data-tool="text"><span class="material-symbols-outlined">text_fields</span></button> <button class="tool-btn" data-tool="image"><span class="material-symbols-outlined">image</span></button> <button class="tool-btn" data-tool="mic"><span class="material-symbols-outlined">mic</span></button> <button class="tool-btn" data-tool="more"><span class="material-symbols-outlined">more_horiz</span></button> </div>
+                    <button class="tool-btn active" data-tool="select"><span class="material-symbols-outlined">select_all</span></button>
+                    <button class="tool-btn" data-tool="edit"><span class="material-symbols-outlined">edit</span></button>
+                    <button class="tool-btn" data-tool="text"><span class="material-symbols-outlined">text_fields</span></button>
+                    <button class="tool-btn" data-tool="image"><span class="material-symbols-outlined">image</span></button>
+                    <button class="tool-btn" data-tool="mic"><span class="material-symbols-outlined">mic</span></button>
+                    <button class="tool-btn" data-tool="more"><span class="material-symbols-outlined">more_horiz</span></button>
+
+                    <div class="tool-options">
+                        <input type="color" id="brushColor" value="#000000" title="Color del pincel">
+                        <input type="range" id="brushSize" min="1" max="50" value="5" title="Grosor del pincel">
+                    </div>
+
+                    <div class="text-options">
+                        <button id="boldBtn" class="format-btn" title="Negrita"><span class="material-symbols-outlined">format_bold</span></button>
+                        <button id="italicBtn" class="format-btn" title="Cursiva"><span class="material-symbols-outlined">format_italic</span></button>
+                        <button id="underlineBtn" class="format-btn" title="Subrayado"><span class="material-symbols-outlined">format_underlined</span></button>
+                        <select id="fontSizeSelect" title="Tamaño de letra">
+                            <option value="16">16</option>
+                            <option value="24" selected>24</option>
+                            <option value="32">32</option>
+                            <option value="48">48</option>
+                        </select>
+                    </div>
+                </div>
             </section>
         </main>
 

--- a/ShareboardApp/css/styles.css
+++ b/ShareboardApp/css/styles.css
@@ -836,6 +836,21 @@ body.viewer-page {
     color: white;
 }
 
+.toolbar-right .tool-options,
+.toolbar-right .text-options {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.toolbar-right .text-options .format-btn {
+    background: none;
+    border: none;
+    padding: 6px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
 /* ------------------------------------------- */
 /* Barra Inferior (Bottom Bar) */
 /* ------------------------------------------- */
@@ -893,6 +908,16 @@ body.viewer-page {
 
     .toolbar-right .tool-btn {
         padding: 8px;
+    }
+
+    .toolbar-right .tool-options,
+    .toolbar-right .text-options {
+        flex-direction: row;
+        margin-top: 4px;
+    }
+
+    .toolbar-right .tool-options input[type="range"] {
+        width: 80px;
     }
 
     .toolbar-right .tool-btn .material-symbols-outlined {

--- a/ShareboardApp/js/canvas-tools.js
+++ b/ShareboardApp/js/canvas-tools.js
@@ -6,6 +6,13 @@ import { uploadImageAndAddToCanvas } from './document-manager.js';
 // Referencia al canvas de Fabric.js proporcionada externamente
 let canvas = null;
 
+let brushColorInput;
+let brushSizeInput;
+let boldBtn;
+let italicBtn;
+let underlineBtn;
+let fontSizeSelect;
+
 // Inicializa la referencia al canvas. Debe llamarse una vez que el lienzo esté creado.
 export function initTools(canvasInstance) {
     canvas = canvasInstance;
@@ -20,6 +27,62 @@ export function initializeTools(toolBtns, isTextEditingFlagCallback) {
         console.error('Tools: Canvas no inicializado. No se pueden inicializar las herramientas.');
         return;
     }
+
+    brushColorInput = document.getElementById('brushColor');
+    brushSizeInput = document.getElementById('brushSize');
+    boldBtn = document.getElementById('boldBtn');
+    italicBtn = document.getElementById('italicBtn');
+    underlineBtn = document.getElementById('underlineBtn');
+    fontSizeSelect = document.getElementById('fontSizeSelect');
+
+    brushColorInput.addEventListener('change', () => {
+        if (canvas.freeDrawingBrush) {
+            canvas.freeDrawingBrush.color = brushColorInput.value;
+        }
+    });
+
+    brushSizeInput.addEventListener('input', () => {
+        if (canvas.freeDrawingBrush) {
+            canvas.freeDrawingBrush.width = parseInt(brushSizeInput.value, 10);
+        }
+    });
+
+    const applyFormat = (prop, value) => {
+        const obj = canvas.getActiveObject();
+        if (obj && obj.isType('i-text')) {
+            obj.set(prop, value);
+            canvas.renderAll();
+            saveCanvasToHistory();
+        }
+    };
+
+    boldBtn.addEventListener('click', () => {
+        const obj = canvas.getActiveObject();
+        if (obj && obj.isType('i-text')) {
+            const newVal = obj.fontWeight === 'bold' ? 'normal' : 'bold';
+            applyFormat('fontWeight', newVal);
+        }
+    });
+
+    italicBtn.addEventListener('click', () => {
+        const obj = canvas.getActiveObject();
+        if (obj && obj.isType('i-text')) {
+            const newVal = obj.fontStyle === 'italic' ? 'normal' : 'italic';
+            applyFormat('fontStyle', newVal);
+        }
+    });
+
+    underlineBtn.addEventListener('click', () => {
+        const obj = canvas.getActiveObject();
+        if (obj && obj.isType('i-text')) {
+            applyFormat('underline', !obj.underline);
+        }
+    });
+
+    fontSizeSelect.addEventListener('change', () => {
+        const size = parseInt(fontSizeSelect.value, 10);
+        applyFormat('fontSize', size);
+    });
 
     // Eventos de Fabric.js para controlar el modo de edición de texto
     canvas.on('text:editing:entered', () => {
@@ -67,9 +130,9 @@ export function initializeTools(toolBtns, isTextEditingFlagCallback) {
         const iText = new fabric.IText('Haz doble clic para editar', {
             left: pointer.x,
             top: pointer.y,
-            fontFamily: 'Roboto', 
+            fontFamily: 'Roboto',
             fill: '#000000',
-            fontSize: 24,
+            fontSize: parseInt(fontSizeSelect.value, 10) || 24,
             selectable: true,
             editable: true // Asegurarse de que sea editable
         });
@@ -121,8 +184,10 @@ export function initializeTools(toolBtns, isTextEditingFlagCallback) {
                     console.log('Tools: Activando Lápiz');
                     canvas.isDrawingMode = true;
                     canvas.freeDrawingBrush = new fabric.PencilBrush(canvas);
-                    canvas.freeDrawingBrush.width = 5;
-                    canvas.freeDrawingBrush.color = '#000000';
+                    canvas.freeDrawingBrush.width = parseInt(brushSizeInput.value, 10) || 5;
+                    canvas.freeDrawingBrush.color = brushColorInput.value || '#000000';
+                    brushSizeInput.value = canvas.freeDrawingBrush.width;
+                    brushColorInput.value = canvas.freeDrawingBrush.color;
                     canvas.defaultCursor = 'crosshair';
                     canvas.hoverCursor = 'crosshair';
                     break;
@@ -130,8 +195,10 @@ export function initializeTools(toolBtns, isTextEditingFlagCallback) {
                     console.log('Tools: Activando Marcador');
                     canvas.isDrawingMode = true;
                     canvas.freeDrawingBrush = new fabric.PencilBrush(canvas); // Usar PencilBrush
-                    canvas.freeDrawingBrush.width = 15;
-                    canvas.freeDrawingBrush.color = 'rgba(0, 255, 0, 0.3)';
+                    canvas.freeDrawingBrush.width = parseInt(brushSizeInput.value, 10) || 15;
+                    canvas.freeDrawingBrush.color = brushColorInput.value || 'rgba(0, 255, 0, 0.3)';
+                    brushSizeInput.value = canvas.freeDrawingBrush.width;
+                    brushColorInput.value = canvas.freeDrawingBrush.color;
                     canvas.defaultCursor = 'crosshair';
                     canvas.hoverCursor = 'crosshair';
                     break;
@@ -139,8 +206,9 @@ export function initializeTools(toolBtns, isTextEditingFlagCallback) {
                     console.log('Tools: Activando Borrador');
                     canvas.isDrawingMode = true;
                     canvas.freeDrawingBrush = new fabric.PencilBrush(canvas); // Usar PencilBrush
-                    canvas.freeDrawingBrush.width = 20;
+                    canvas.freeDrawingBrush.width = parseInt(brushSizeInput.value, 10) || 20;
                     canvas.freeDrawingBrush.globalCompositeOperation = 'destination-out'; // Modo borrador
+                    brushSizeInput.value = canvas.freeDrawingBrush.width;
                     break;
                 case 'select': // Selector (cursor)
                     console.log('Tools: Activando Selector');


### PR DESCRIPTION
## Summary
- allow choosing brush color and size
- support text formatting (bold/italic/underline/font size)
- style new controls
- document formatting features in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844fc2c9bd483279e645f29441880a5